### PR TITLE
Enhance View renderer with template inheritance, auto-escaping, stacks, composers, and helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .phpintel
 .DS_Store
+.phpunit.result.cache
 composer.lock
 vendor
 /docs/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ composer.lock
 vendor
 /docs/*
 !/docs/assets
+!/docs/*.md
 /dist/*
 !/dist/.gitkeep

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ $ composer require caffeina-core/core
 
 See the [wiki](https://github.com/caffeina-core/core/wiki).
 
+Component documentation:
+
+- [View](docs/View.md) - Template engine with layouts, auto-escaping, stacks, composers, and caching
+
 
 ## Contributing
 

--- a/classes/View.php
+++ b/classes/View.php
@@ -5,6 +5,15 @@
  *
  * View template handling class.
  *
+ * Provides a facade to the underlying template engine adapter with support for:
+ *   - Template inheritance (layouts with extend/section/yield)
+ *   - Auto-escaped output (safe by default)
+ *   - Stacks for CSS/JS asset injection
+ *   - View composers for automatic data injection
+ *   - Render caching via the Cache component
+ *   - Custom template helpers
+ *   - Isolated includes and inheriting embeds
+ *
  * @package core
  * @author stefano.azzolini@caffeinalab.com
  * @copyright Caffeina srl - 2015 - http://caffeina.it
@@ -17,14 +26,17 @@ class View {
     protected $options = [
       'template'  => '',
       'data'      => [],
+      'cache_ttl' => 0,
     ];
 
     /**
-     * Construct a new view based on the passed template
-     * @param  mixed $template The template path or an array of them.
+     * Construct a new view based on the passed template.
+     *
+     * @param  mixed $template The template path or an array of fallback paths.
+     * @throws Exception If no template in the list exists.
      */
-    public function __construct($template){
-      foreach ((array)$template as $templ){
+    public function __construct($template) {
+      foreach ((array)$template as $templ) {
         if (static::$handler->exists($templ))
           return $this->options['template'] = $templ;
       }
@@ -32,74 +44,141 @@ class View {
     }
 
     /**
-     * Load a Template Handler
-     * @param  class $handler The template handler class instance
+     * Load a Template Handler.
+     *
+     * @param  View\Adapter $handler The template handler adapter instance
      */
-    public static function using(View\Adapter $handler){
+    public static function using(View\Adapter $handler) {
       static::$handler = $handler;
     }
 
     /**
-     * View factory method, can optionally pass data to pre-init view
+     * View factory method, can optionally pass data to pre-init the view.
+     *
      * @param  string $template The template path
-     * @param  array $data     The key-value map of data to pass to the view
+     * @param  array  $data     The key-value map of data to pass to the view
      * @return View
      */
-    public static function from($template,$data=null){
+    public static function from($template, $data = null) {
       $view = new self($template);
       return $data ? $view->with($data) : $view;
     }
 
     /**
-     * Assigns data to the view
-     * @param  array $data     The key-value map of data to pass to the view
-     * @return View
+     * Assigns data to the view. Last call wins (later data overrides earlier).
+     *
+     * @param  array $data  The key-value map of data to pass to the view
+     * @return View  Chainable
      */
-    public function with($data){
-      if ($data){
-        $tmp = array_merge($data, (isset($this->options['data'])?$this->options['data']:[]));
-        $this->options['data'] = $tmp;
+    public function with($data) {
+      if ($data) {
+        $this->options['data'] = array_merge($this->options['data'], $data);
       }
       return $this;
     }
 
     /**
-     * Render view when casted to a string
-     * @return string The rendered view
+     * Enable render caching for this view instance.
+     *
+     * Requires the Cache component. The cache key is derived from the
+     * template name and a hash of the view data.
+     *
+     * @param  int  $ttl  Cache time-to-live in seconds
+     * @return View Chainable
      */
-    public function __toString(){
-      return Filter::with('core.view',static::$handler->render($this->options['template'],$this->options['data']));
+    public function cache($ttl) {
+      $this->options['cache_ttl'] = (int)$ttl;
+      return $this;
     }
 
     /**
-     * Returns the handler instance
-     * @return mixed
+     * Render view when casted to a string.
+     *
+     * If caching is enabled, the rendered output is stored/retrieved via Cache.
+     *
+     * @return string The rendered view
      */
-    public static function & handler(){
+    public function __toString() {
+      $rendered = null;
+      $ttl = $this->options['cache_ttl'];
+
+      if ($ttl > 0 && class_exists('Cache', false)) {
+        $cacheKey = 'view:' . $this->options['template'] . ':' . md5(serialize($this->options['data']));
+        $template = $this->options['template'];
+        $data     = $this->options['data'];
+        $handler  = static::$handler;
+        $rendered = Cache::get($cacheKey, function () use ($handler, $template, $data) {
+          return $handler->render($template, $data);
+        }, $ttl);
+      } else {
+        $rendered = static::$handler->render($this->options['template'], $this->options['data']);
+      }
+
+      return Filter::with('core.view', $rendered);
+    }
+
+    /**
+     * Returns the handler instance.
+     *
+     * @return View\Adapter
+     */
+    public static function & handler() {
       return static::$handler;
     }
 
     /**
-     * Check if a template exists
+     * Check if a template exists.
+     *
+     * @param  string $templatePath
      * @return bool
      */
-    public static function exists($templatePath){
+    public static function exists($templatePath) {
       return static::$handler->exists($templatePath);
     }
 
-
     /**
-     * Propagate the call to the handler
+     * Register a custom template helper available as $this->name() in templates.
+     *
+     * @param string   $name
+     * @param callable $fn
      */
-    public function __call($n,$p){
-      return call_user_func_array([static::$handler,$n],$p);
+    public static function helper($name, callable $fn) {
+      static::$handler->addHelper($name, $fn);
     }
 
     /**
-     * Propagate the static call to the handler
+     * Register multiple template helpers at once.
+     *
+     * @param array $helpers  Map of name => callable
      */
-    public static function __callStatic($n,$p){
-      return forward_static_call_array([static::$handler,$n],$p);
+    public static function helpers(array $helpers) {
+      static::$handler->addHelpers($helpers);
+    }
+
+    /**
+     * Register a view composer for automatic data injection.
+     *
+     * Composers run before a template renders. Supports wildcard patterns.
+     *
+     * @param string   $pattern   Template name or glob pattern (e.g. "admin/*")
+     * @param callable $callback  Receives &$data by reference
+     */
+    public static function composer($pattern, callable $callback) {
+      static::$handler->composer($pattern, $callback);
+    }
+
+    /**
+     * Propagate the call to the handler.
+     */
+    public function __call($n, $p) {
+      return call_user_func_array([static::$handler, $n], $p);
+    }
+
+    /**
+     * Propagate the static call to the handler.
+     */
+    public static function __callStatic($n, $p) {
+      return forward_static_call_array([static::$handler, $n], $p);
     }
 
 }

--- a/classes/View/Adapter.php
+++ b/classes/View/Adapter.php
@@ -5,6 +5,8 @@
  *
  * Core\View\Adapter Interface.
  *
+ * All template engine adapters must implement this contract.
+ *
  * @package core
  * @author stefano.azzolini@caffeina.com
  * @copyright Caffeina srl - 2015 - http://caffeina.com
@@ -13,9 +15,11 @@
 namespace View;
 
 interface Adapter {
-    public function __construct($path=null, $options=[]);
-    public function render($template,$data=[]);
+    public function __construct($path = null, $options = []);
+    public function render($template, $data = []);
     public static function exists($path);
-    public static function addGlobal($key,$val);
+    public static function addGlobal($key, $val);
     public static function addGlobals(array $defs);
+    public static function addHelper($name, callable $fn);
+    public static function addHelpers(array $helpers);
 }

--- a/classes/View/PHP.php
+++ b/classes/View/PHP.php
@@ -130,6 +130,11 @@ class PHP implements Adapter {
 
         $scope = new Scope($data, $sections);
 
+        // Set active scope for global template functions, preserving any
+        // outer scope (e.g. when rendering includes inside a render).
+        $previousScope = Scope::$current;
+        Scope::$current = $scope;
+
         $template_path = self::$templatePath . trim($template, '/') . static::EXTENSION;
 
         // Execute template in sandbox
@@ -140,6 +145,9 @@ class PHP implements Adapter {
         };
 
         $output = call_user_func($sandbox->bindTo($scope));
+
+        // Restore previous scope
+        Scope::$current = $previousScope;
 
         // If the template declared a parent via extend(), render the parent
         // with all captured sections and stacks flowing upward.

--- a/classes/View/PHP.php
+++ b/classes/View/PHP.php
@@ -3,7 +3,15 @@
 /**
  * View\PHP
  *
- * Core\View PHP templates bridge.
+ * Core\View PHP template engine.
+ *
+ * Features:
+ *   - Template inheritance (extend/section/yield)
+ *   - Auto-escaped variable output
+ *   - Stacks for asset injection (push/stack)
+ *   - View composers via Event system
+ *   - Isolated includes and inheriting embeds
+ *   - Custom template helpers
  *
  * @package core
  * @author stefano.azzolini@caffeina.com
@@ -14,61 +22,136 @@ namespace View;
 
 class PHP implements Adapter {
 
-  const EXTENSION = '.php';
+    const EXTENSION = '.php';
 
-  protected static $templatePath,
-                   $globals = [];
+    protected static $templatePath  = '',
+                     $globals       = [],
+                     $composers     = [];
 
-  public function __construct($path=null,$options=[]){
-      self::$templatePath = ($path ? rtrim($path,'/') : __DIR__) . '/';
-  }
+    public function __construct($path = null, $options = []) {
+        self::$templatePath = ($path ? rtrim($path, '/') : __DIR__) . '/';
+    }
 
-  public static function exists($path){
-      return is_file(self::$templatePath . $path . static::EXTENSION);
-  }
+    /**
+     * Check if a template file exists.
+     *
+     * @param  string $path  Template path (without extension)
+     * @return bool
+     */
+    public static function exists($path) {
+        return is_file(self::$templatePath . $path . static::EXTENSION);
+    }
 
-  public static function addGlobal($key,$val){
-    self::$globals[$key] = $val;
-  }
-
-  public static function addGlobals(array $defs){
-    foreach ((array)$defs as $key=>$val) {
+    /**
+     * Register a global variable available in all templates.
+     *
+     * @param string $key
+     * @param mixed  $val
+     */
+    public static function addGlobal($key, $val) {
         self::$globals[$key] = $val;
     }
-  }
 
-  public function render($template, $data=[]){
-      $template_path = self::$templatePath . trim($template,'/') . static::EXTENSION;
-      $sandbox = function() use ($template_path){
-          ob_start();
-          include($template_path);
-          $__buffer__ = ob_get_contents();
-          ob_end_clean();
-          return $__buffer__;
-      };
-      return call_user_func($sandbox->bindTo(new PHPContext(
-          array_merge(self::$globals, $data),
-          self::$templatePath
-      )));
-  }
-}
+    /**
+     * Register multiple global variables.
+     *
+     * @param array $defs  Key-value pairs
+     */
+    public static function addGlobals(array $defs) {
+        foreach ($defs as $key => $val) {
+            self::$globals[$key] = $val;
+        }
+    }
 
-class PHPContext {
-  protected $data = [];
+    /**
+     * Register a custom template helper.
+     *
+     * @param string   $name
+     * @param callable $fn
+     */
+    public static function addHelper($name, callable $fn) {
+        Scope::addHelper($name, $fn);
+    }
 
-  public function __construct($data=[], $path=null){
-      $this->data = $data;
-  }
+    /**
+     * Register multiple template helpers.
+     *
+     * @param array $helpers  Map of name => callable
+     */
+    public static function addHelpers(array $helpers) {
+        Scope::addHelpers($helpers);
+    }
 
-  public function partial($template, $vars=[]){
-      return \View::from($template,array_merge($this->data,$vars));
-  }
+    /**
+     * Register a view composer callback for a template or pattern.
+     *
+     * Composers are called before a template renders, allowing automatic
+     * injection of data. Supports wildcard patterns (e.g. "admin/*").
+     *
+     * @param string   $pattern   Template name or glob pattern
+     * @param callable $callback  Receives &$data by reference
+     */
+    public static function composer($pattern, callable $callback) {
+        self::$composers[] = [$pattern, $callback];
+    }
 
-  public function __isset($n){ return true; }
+    /**
+     * Render a template with data.
+     *
+     * Handles template inheritance by executing child templates first,
+     * then recursively rendering parent layouts with captured sections.
+     *
+     * @param  string $template  Template path (without extension)
+     * @param  array  $data      View data
+     * @param  array  $sections  Sections inherited from child template
+     * @param  bool   $topLevel  Whether this is the top-level render call
+     * @return string
+     */
+    public function render($template, $data = [], $sections = [], $topLevel = true) {
 
-  public function __unset($n){}
+        $data = array_merge(self::$globals, $data);
 
-  public function __get($n){
-    return empty($this->data[$n]) ? '' : $this->data[$n];
-  }
+        // Fire view composers (exact match and wildcard)
+        foreach (self::$composers as list($pattern, $callback)) {
+            if ($pattern === $template || fnmatch($pattern, $template)) {
+                $callback($data);
+            }
+        }
+
+        // Fire event-based composers for exact template match
+        if (class_exists('Event', false)) {
+            \Event::trigger("core.view.compose:{$template}", $data);
+        }
+
+        // Reset stacks at the start of a top-level render
+        if ($topLevel) {
+            Scope::resetStacks();
+        }
+
+        $scope = new Scope($data, $sections);
+
+        $template_path = self::$templatePath . trim($template, '/') . static::EXTENSION;
+
+        // Execute template in sandbox
+        $sandbox = function () use ($template_path) {
+            ob_start();
+            include($template_path);
+            return ob_get_clean();
+        };
+
+        $output = call_user_func($sandbox->bindTo($scope));
+
+        // If the template declared a parent via extend(), render the parent
+        // with all captured sections and stacks flowing upward.
+        if ($parent = $scope->getParent()) {
+            return $this->render(
+                $parent,
+                $data,
+                array_merge($sections, $scope->getSections()),
+                false
+            );
+        }
+
+        return $output;
+    }
 }

--- a/classes/View/Scope.php
+++ b/classes/View/Scope.php
@@ -6,7 +6,12 @@
  * Template execution scope providing variable access, template inheritance,
  * output escaping, stacks, and custom helper support.
  *
- * Replaces the old PHPContext with a full-featured template context.
+ * Inside templates, two APIs are available:
+ *   - OOP:       $this->section('content')
+ *   - Functions: section('content')
+ *
+ * Both styles can be mixed freely. The plain functions delegate to the
+ * active Scope instance stored in Scope::$current.
  *
  * @package core
  * @author stefano.azzolini@caffeina.com
@@ -26,11 +31,18 @@ class Scope {
     protected static $helpers = [];
 
     /**
+     * The currently executing scope instance.
+     * Set by View\PHP::render(), used by the global helper functions.
+     *
+     * @var Scope|null
+     */
+    public static $current = null;
+
+    /**
      * Create a new template scope.
      *
      * @param array  $data     The view data (merged globals + local)
      * @param array  $sections Sections inherited from a child template
-     * @param array  $stacks   Stacks inherited from a child template
      */
     public function __construct(array $data = [], array $sections = []) {
         $this->data     = $data;
@@ -110,8 +122,6 @@ class Scope {
 
     /**
      * Declare that this template extends a parent layout.
-     * The parent template will be rendered after the child finishes,
-     * with all captured sections available via yield().
      *
      * @param string $layout  The parent template path
      */
@@ -121,7 +131,6 @@ class Scope {
 
     /**
      * Begin capturing a named section.
-     * Must be paired with endSection().
      *
      * @param string $name
      */
@@ -173,7 +182,6 @@ class Scope {
 
     /**
      * Begin pushing content onto a named stack.
-     * Stacks are global across all templates in a render cycle.
      *
      * @param string $name
      */
@@ -235,7 +243,6 @@ class Scope {
 
     /**
      * Include a sub-template with isolated data (only passed data + globals).
-     * The parent scope's data is NOT inherited.
      *
      * @param  string $template
      * @param  array  $data
@@ -313,3 +320,6 @@ class Scope {
         static::$helpers = [];
     }
 }
+
+// Load global template functions (e(), raw(), section(), yields(), etc.)
+require_once __DIR__ . '/functions.php';

--- a/classes/View/Scope.php
+++ b/classes/View/Scope.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * View\Scope
+ *
+ * Template execution scope providing variable access, template inheritance,
+ * output escaping, stacks, and custom helper support.
+ *
+ * Replaces the old PHPContext with a full-featured template context.
+ *
+ * @package core
+ * @author stefano.azzolini@caffeina.com
+ * @copyright Caffeina srl - 2015 - http://caffeina.com
+ */
+
+namespace View;
+
+class Scope {
+
+    protected $data       = [];
+    protected $parent     = null;
+    protected $sections   = [];
+    protected $openBuffer = null;
+
+    protected static $stacks  = [];
+    protected static $helpers = [];
+
+    /**
+     * Create a new template scope.
+     *
+     * @param array  $data     The view data (merged globals + local)
+     * @param array  $sections Sections inherited from a child template
+     * @param array  $stacks   Stacks inherited from a child template
+     */
+    public function __construct(array $data = [], array $sections = []) {
+        $this->data     = $data;
+        $this->sections = $sections;
+    }
+
+    // ─── Variable Access ──────────────────────────────────────────────
+
+    /**
+     * Access a view variable with automatic HTML escaping.
+     * Returns an empty string for undefined keys.
+     *
+     * @param  string $key
+     * @return mixed  Escaped string for string values, raw value otherwise
+     */
+    public function __get($key) {
+        $val = $this->data[$key] ?? '';
+        return is_string($val) ? htmlspecialchars($val, ENT_QUOTES, 'UTF-8') : $val;
+    }
+
+    /**
+     * Access a view variable without escaping.
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function raw($key) {
+        return $this->data[$key] ?? '';
+    }
+
+    /**
+     * Manually escape a value with a named strategy.
+     * Strategies are extensible via Filter::add('core.view.escape.{strategy}', ...).
+     *
+     * @param  mixed  $value
+     * @param  string $strategy  One of: html, url, js, css
+     * @return string
+     */
+    public function e($value, $strategy = 'html') {
+        // Compute built-in default, then let Filter override if registered
+        switch ($strategy) {
+            case 'url':
+                $default = rawurlencode($value);
+                break;
+            case 'js':
+                $default = json_encode($value, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+                break;
+            case 'css':
+                $default = preg_replace_callback('/[^a-zA-Z0-9]/', function ($m) {
+                    return '\\' . dechex(ord($m[0])) . ' ';
+                }, $value);
+                break;
+            case 'html':
+            default:
+                $default = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+                break;
+        }
+        return \Filter::with("core.view.escape.{$strategy}", $default);
+    }
+
+    /**
+     * Check if a view variable is defined and non-empty.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function __isset($key) {
+        return isset($this->data[$key]);
+    }
+
+    /**
+     * No-op for unset.
+     */
+    public function __unset($key) {}
+
+    // ─── Template Inheritance ─────────────────────────────────────────
+
+    /**
+     * Declare that this template extends a parent layout.
+     * The parent template will be rendered after the child finishes,
+     * with all captured sections available via yield().
+     *
+     * @param string $layout  The parent template path
+     */
+    public function extend($layout) {
+        $this->parent = $layout;
+    }
+
+    /**
+     * Begin capturing a named section.
+     * Must be paired with endSection().
+     *
+     * @param string $name
+     */
+    public function section($name) {
+        $this->openBuffer = $name;
+        ob_start();
+    }
+
+    /**
+     * End the current section capture.
+     */
+    public function endSection() {
+        if ($this->openBuffer !== null) {
+            $this->sections[$this->openBuffer] = ob_get_clean();
+            $this->openBuffer = null;
+        }
+    }
+
+    /**
+     * Output a named section's content, or a default if the section was not defined.
+     *
+     * @param  string $name
+     * @param  string $default  Fallback content if section is undefined
+     * @return string
+     */
+    public function yield($name, $default = '') {
+        return $this->sections[$name] ?? $default;
+    }
+
+    /**
+     * Returns the parent layout path, or null if none was set.
+     *
+     * @return string|null
+     */
+    public function getParent() {
+        return $this->parent;
+    }
+
+    /**
+     * Returns all captured sections.
+     *
+     * @return array
+     */
+    public function getSections() {
+        return $this->sections;
+    }
+
+    // ─── Stacks ───────────────────────────────────────────────────────
+
+    /**
+     * Begin pushing content onto a named stack.
+     * Stacks are global across all templates in a render cycle.
+     *
+     * @param string $name
+     */
+    public function push($name) {
+        $this->openBuffer = '_stack:' . $name;
+        ob_start();
+    }
+
+    /**
+     * End the current push capture and append to the stack.
+     */
+    public function endPush() {
+        if ($this->openBuffer !== null && strpos($this->openBuffer, '_stack:') === 0) {
+            $name = substr($this->openBuffer, 7);
+            static::$stacks[$name][] = ob_get_clean();
+            $this->openBuffer = null;
+        }
+    }
+
+    /**
+     * Begin prepending content onto a named stack.
+     *
+     * @param string $name
+     */
+    public function prepend($name) {
+        $this->openBuffer = '_prepend:' . $name;
+        ob_start();
+    }
+
+    /**
+     * End the current prepend capture and prepend to the stack.
+     */
+    public function endPrepend() {
+        if ($this->openBuffer !== null && strpos($this->openBuffer, '_prepend:') === 0) {
+            $name = substr($this->openBuffer, 9);
+            array_unshift(static::$stacks[$name], ob_get_clean());
+            $this->openBuffer = null;
+        }
+    }
+
+    /**
+     * Output all content pushed onto a named stack.
+     *
+     * @param  string $name
+     * @return string
+     */
+    public function stack($name) {
+        return implode("\n", static::$stacks[$name] ?? []);
+    }
+
+    /**
+     * Reset all stacks. Called at the start of a top-level render.
+     */
+    public static function resetStacks() {
+        static::$stacks = [];
+    }
+
+    // ─── Includes & Embeds ────────────────────────────────────────────
+
+    /**
+     * Include a sub-template with isolated data (only passed data + globals).
+     * The parent scope's data is NOT inherited.
+     *
+     * @param  string $template
+     * @param  array  $data
+     * @return string
+     */
+    public function include($template, $data = []) {
+        return (string) \View::from($template, $data);
+    }
+
+    /**
+     * Embed a sub-template inheriting the current scope's data, merged with overrides.
+     *
+     * @param  string $template
+     * @param  array  $data      Overrides merged on top of parent data
+     * @return string
+     */
+    public function embed($template, $data = []) {
+        return (string) \View::from($template, array_merge($this->data, $data));
+    }
+
+    // ─── Custom Helpers ───────────────────────────────────────────────
+
+    /**
+     * Register a custom helper function available in all templates.
+     *
+     * @param string   $name
+     * @param callable $fn
+     */
+    public static function addHelper($name, callable $fn) {
+        static::$helpers[$name] = $fn;
+    }
+
+    /**
+     * Register multiple helpers at once.
+     *
+     * @param array $helpers  Map of name => callable
+     */
+    public static function addHelpers(array $helpers) {
+        foreach ($helpers as $name => $fn) {
+            static::addHelper($name, $fn);
+        }
+    }
+
+    /**
+     * Dispatch calls to registered helpers.
+     *
+     * @param  string $name
+     * @param  array  $args
+     * @return mixed
+     * @throws \BadMethodCallException
+     */
+    public function __call($name, $args) {
+        if (isset(static::$helpers[$name])) {
+            return call_user_func_array(
+                \Closure::bind(static::$helpers[$name], $this, static::class),
+                $args
+            );
+        }
+        throw new \BadMethodCallException("Unknown template helper: {$name}");
+    }
+
+    /**
+     * Returns all registered helpers.
+     *
+     * @return array
+     */
+    public static function getHelpers() {
+        return static::$helpers;
+    }
+
+    /**
+     * Clear all registered helpers (useful for testing).
+     */
+    public static function clearHelpers() {
+        static::$helpers = [];
+    }
+}

--- a/classes/View/functions.php
+++ b/classes/View/functions.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * View Template Functions
+ *
+ * Plain global functions available inside any PHP template.
+ * Each function delegates to the active View\Scope instance.
+ *
+ * Usage in templates:
+ *   <?php extend('layouts/main') ?>
+ *   <?php section('content') ?>...<?php endSection() ?>
+ *   <?= yields('content') ?>
+ *   <?= e($value, 'url') ?>
+ *   <?= partial('components/card', ['title' => 'Hi']) ?>
+ *
+ * Note: `yield` and `include` are PHP reserved words, so we use
+ * `yields()` and `partial()` as the global function names.
+ * The $this-> methods ($this->yield(), $this->include()) still work.
+ *
+ * @package core
+ * @author stefano.azzolini@caffeina.com
+ * @copyright Caffeina srl - 2015 - http://caffeina.com
+ */
+
+/**
+ * Escape a value using a named strategy.
+ *
+ * @param  mixed  $value
+ * @param  string $strategy  html|url|js|css
+ * @return string
+ */
+function e($value, $strategy = 'html') {
+    return View\Scope::$current->e($value, $strategy);
+}
+
+/**
+ * Access a view variable without escaping.
+ *
+ * @param  string $key
+ * @return mixed
+ */
+function raw($key) {
+    return View\Scope::$current->raw($key);
+}
+
+/**
+ * Declare that this template extends a parent layout.
+ *
+ * @param string $layout
+ */
+function extend($layout) {
+    View\Scope::$current->extend($layout);
+}
+
+/**
+ * Begin capturing a named section.
+ *
+ * @param string $name
+ */
+function section($name) {
+    View\Scope::$current->section($name);
+}
+
+/**
+ * End the current section capture.
+ */
+function endSection() {
+    View\Scope::$current->endSection();
+}
+
+/**
+ * Output a named section, or a default value.
+ * Named `yields` because `yield` is a PHP reserved word.
+ *
+ * @param  string $name
+ * @param  string $default
+ * @return string
+ */
+function yields($name, $default = '') {
+    return View\Scope::$current->yield($name, $default);
+}
+
+/**
+ * Begin pushing content onto a named stack.
+ *
+ * @param string $name
+ */
+function push($name) {
+    View\Scope::$current->push($name);
+}
+
+/**
+ * End the current push capture.
+ */
+function endPush() {
+    View\Scope::$current->endPush();
+}
+
+/**
+ * Begin prepending content onto a named stack.
+ *
+ * @param string $name
+ */
+function prepend($name) {
+    View\Scope::$current->prepend($name);
+}
+
+/**
+ * End the current prepend capture.
+ */
+function endPrepend() {
+    View\Scope::$current->endPrepend();
+}
+
+/**
+ * Output all content pushed onto a named stack.
+ *
+ * @param  string $name
+ * @return string
+ */
+function stack($name) {
+    return View\Scope::$current->stack($name);
+}
+
+/**
+ * Include a sub-template with isolated data.
+ * Named `partial` because `include` is a PHP reserved word.
+ *
+ * @param  string $template
+ * @param  array  $data
+ * @return string
+ */
+function partial($template, $data = []) {
+    return View\Scope::$current->include($template, $data);
+}
+
+/**
+ * Embed a sub-template inheriting the current scope's data.
+ *
+ * @param  string $template
+ * @param  array  $data
+ * @return string
+ */
+function embed($template, $data = []) {
+    return View\Scope::$current->embed($template, $data);
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5"
+        "phpunit/phpunit": "^9"
     },
     "scripts": {
         "test-lint" : "find classes -type f -name '*.php' -exec php -l {} \\;",

--- a/docs/View.md
+++ b/docs/View.md
@@ -1,0 +1,764 @@
+# View
+
+The View component is Core's built-in PHP template engine. It provides a safe, powerful template layer using plain PHP files — no custom syntax to learn, full IDE support, and zero compilation overhead.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Setup](#setup)
+- [Rendering Templates](#rendering-templates)
+- [Variable Access & Auto-Escaping](#variable-access--auto-escaping)
+- [Template Inheritance](#template-inheritance)
+- [Sections & Yields](#sections--yields)
+- [Stacks (CSS/JS Injection)](#stacks-cssjs-injection)
+- [Includes & Embeds](#includes--embeds)
+- [Custom Helpers](#custom-helpers)
+- [View Composers](#view-composers)
+- [Global Variables](#global-variables)
+- [Template Caching](#template-caching)
+- [Template Fallbacks](#template-fallbacks)
+- [Escape Strategies](#escape-strategies)
+- [Adapter Interface](#adapter-interface)
+- [Integration with Routes](#integration-with-routes)
+- [Full Example: Blog Application](#full-example-blog-application)
+
+---
+
+## Quick Start
+
+```php
+// 1. Point the engine at your templates directory
+View::using(new View\PHP(__DIR__ . '/templates'));
+
+// 2. Render a template
+echo View::from('welcome', ['name' => 'World']);
+```
+
+`templates/welcome.php`:
+```php
+<h1>Hello, <?= $this->name ?>!</h1>
+```
+
+Output:
+```html
+<h1>Hello, World!</h1>
+```
+
+---
+
+## Setup
+
+Initialize the View engine with a template directory path:
+
+```php
+View::using(new View\PHP('/path/to/templates'));
+```
+
+All template paths are resolved relative to this root. Templates use the `.php` extension automatically.
+
+---
+
+## Rendering Templates
+
+### Factory method (recommended)
+
+```php
+$view = View::from('page', ['title' => 'Home']);
+echo $view;
+```
+
+### Constructor
+
+```php
+$view = new View('page');
+$view->with(['title' => 'Home']);
+echo $view;
+```
+
+### Chaining
+
+```php
+echo View::from('page')
+    ->with(['title' => 'Home'])
+    ->with(['user'  => $currentUser])
+    ->cache(3600);
+```
+
+When `with()` is called multiple times, later calls override earlier values for the same key.
+
+---
+
+## Variable Access & Auto-Escaping
+
+The View engine is **safe by default**. All string values accessed via `$this->key` are automatically HTML-escaped to prevent XSS attacks.
+
+### Auto-escaped output (default)
+
+```php
+<!-- Template: greeting.php -->
+<p>Hello, <?= $this->username ?>!</p>
+```
+
+If `username` is `<script>alert('xss')</script>`, the output will be:
+
+```html
+<p>Hello, &lt;script&gt;alert(&#039;xss&#039;)&lt;/script&gt;!</p>
+```
+
+### Raw (unescaped) output
+
+When you trust the content (e.g., pre-sanitized HTML), use `raw()`:
+
+```php
+<div class="content"><?= $this->raw('htmlContent') ?></div>
+```
+
+### Manual escaping with strategies
+
+Use `e()` for non-HTML escaping contexts:
+
+```php
+<a href="?q=<?= $this->e($this->raw('query'), 'url') ?>">Search</a>
+<script>var name = <?= $this->e($this->raw('name'), 'js') ?>;</script>
+<style>content: '<?= $this->e($this->raw('icon'), 'css') ?>';</style>
+```
+
+### Non-string values
+
+Integers, floats, arrays, and objects pass through without escaping:
+
+```php
+<span>Count: <?= $this->count ?></span>  <!-- Integer, no escaping needed -->
+```
+
+### Checking if a variable exists
+
+Unlike the old behavior where `isset()` always returned true, the new `View\Scope` provides truthful `isset()` checks:
+
+```php
+<?php if (isset($this->subtitle)): ?>
+    <h2><?= $this->subtitle ?></h2>
+<?php endif ?>
+```
+
+---
+
+## Template Inheritance
+
+Build layouts with parent/child relationships, similar to Blade's `@extends` or Twig's `{% extends %}`.
+
+### Layout template
+
+`templates/layouts/main.php`:
+```php
+<!DOCTYPE html>
+<html>
+<head>
+    <title><?= $this->yield('title', 'My App') ?></title>
+    <?= $this->stack('styles') ?>
+</head>
+<body>
+    <header>
+        <?= $this->yield('header', '<nav>Default Nav</nav>') ?>
+    </header>
+
+    <main>
+        <?= $this->yield('content') ?>
+    </main>
+
+    <footer>
+        <?= $this->yield('footer', '&copy; 2024 My App') ?>
+    </footer>
+
+    <?= $this->stack('scripts') ?>
+</body>
+</html>
+```
+
+### Child template
+
+`templates/pages/about.php`:
+```php
+<?php $this->extend('layouts/main') ?>
+
+<?php $this->section('title') ?>About Us<?php $this->endSection() ?>
+
+<?php $this->section('content') ?>
+    <h1>About Us</h1>
+    <p>Welcome to our about page.</p>
+<?php $this->endSection() ?>
+```
+
+### How it works
+
+1. The child template calls `$this->extend('layouts/main')` to declare its parent
+2. Content between `$this->section('name')` and `$this->endSection()` is captured
+3. The parent layout renders, calling `$this->yield('name')` to place sections
+4. Sections not defined by the child use the default value from `yield()`
+
+### Multi-level inheritance
+
+Templates can extend other templates that themselves extend a layout:
+
+`templates/layouts/admin.php`:
+```php
+<?php $this->extend('layouts/main') ?>
+
+<?php $this->section('header') ?>
+    <nav>Admin Navigation</nav>
+<?php $this->endSection() ?>
+
+<?php $this->section('content') ?>
+    <div class="admin-layout">
+        <aside><?= $this->yield('sidebar') ?></aside>
+        <div class="admin-content"><?= $this->yield('admin_content') ?></div>
+    </div>
+<?php $this->endSection() ?>
+```
+
+`templates/admin/dashboard.php`:
+```php
+<?php $this->extend('layouts/admin') ?>
+
+<?php $this->section('admin_content') ?>
+    <h1>Dashboard</h1>
+    <p>Welcome back, <?= $this->name ?>!</p>
+<?php $this->endSection() ?>
+```
+
+This produces a three-level hierarchy: `dashboard` -> `admin layout` -> `main layout`.
+
+---
+
+## Sections & Yields
+
+### `$this->section($name)` / `$this->endSection()`
+
+Capture a block of HTML to be placed into a layout:
+
+```php
+<?php $this->section('sidebar') ?>
+    <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/about">About</a></li>
+    </ul>
+<?php $this->endSection() ?>
+```
+
+### `$this->yield($name, $default = '')`
+
+Output a section in a layout. If the child didn't define this section, the default is used:
+
+```php
+<?= $this->yield('sidebar', '<p>No sidebar</p>') ?>
+```
+
+---
+
+## Stacks (CSS/JS Injection)
+
+Stacks allow child templates and included sub-templates to inject CSS and JavaScript into the layout's `<head>` or before `</body>`.
+
+### Defining stack slots in the layout
+
+```php
+<head>
+    <link rel="stylesheet" href="/css/app.css">
+    <?= $this->stack('styles') ?>
+</head>
+<body>
+    <?= $this->yield('content') ?>
+
+    <script src="/js/app.js"></script>
+    <?= $this->stack('scripts') ?>
+</body>
+```
+
+### Pushing to stacks from child templates
+
+```php
+<?php $this->push('styles') ?>
+    <link rel="stylesheet" href="/css/dashboard.css">
+<?php $this->endPush() ?>
+
+<?php $this->push('scripts') ?>
+    <script src="/js/charts.js"></script>
+<?php $this->endPush() ?>
+```
+
+### Prepending to stacks
+
+Use `prepend()` to add content to the beginning of a stack:
+
+```php
+<?php $this->prepend('scripts') ?>
+    <script src="/js/vendor/jquery.js"></script>
+<?php $this->endPrepend() ?>
+```
+
+Stacks are **global** across the render cycle. An `include()`d sub-template can push to a stack and it will surface in the layout.
+
+---
+
+## Includes & Embeds
+
+Two ways to compose templates from smaller parts:
+
+### `$this->include($template, $data)` — Isolated
+
+The included template receives **only** the explicitly passed data (plus globals). It does NOT inherit the parent template's variables.
+
+```php
+<!-- Parent has $this->name = 'Rick' -->
+<?= $this->include('components/card', ['title' => 'My Card']) ?>
+<!-- The card template cannot access 'name', only 'title' -->
+```
+
+Use `include()` for reusable components that should not depend on context.
+
+### `$this->embed($template, $data)` — Inheriting
+
+The embedded template receives the parent's data merged with any overrides.
+
+```php
+<!-- Parent has $this->name = 'Rick' -->
+<?= $this->embed('partials/sidebar') ?>
+<!-- sidebar can access 'name' because it inherits parent data -->
+
+<?= $this->embed('partials/sidebar', ['name' => 'Daryl']) ?>
+<!-- sidebar sees name='Daryl' (override wins) -->
+```
+
+Use `embed()` for layout fragments that need access to the current view's context.
+
+---
+
+## Custom Helpers
+
+Register functions that become available as `$this->helperName()` in all templates.
+
+### Registering helpers
+
+```php
+// Single helper
+View::helper('formatDate', function ($date, $format = 'Y-m-d') {
+    return date($format, strtotime($date));
+});
+
+// Multiple helpers at once
+View::helpers([
+    'uppercase' => function ($text) {
+        return strtoupper($text);
+    },
+    'truncate' => function ($text, $length = 100) {
+        return strlen($text) > $length
+            ? substr($text, 0, $length) . '...'
+            : $text;
+    },
+]);
+```
+
+### Using helpers in templates
+
+```php
+<time><?= $this->formatDate($this->raw('created_at'), 'd M Y') ?></time>
+<h1><?= $this->uppercase($this->raw('title')) ?></h1>
+<p><?= $this->truncate($this->raw('body'), 200) ?></p>
+```
+
+Helpers receive raw values as arguments, so pass `$this->raw('key')` if you want the unescaped value for processing (e.g., date parsing). The helper's return value is output directly, so escape it yourself if it contains user input.
+
+---
+
+## View Composers
+
+Composers automatically inject data into templates before they render. This avoids repeating the same data-passing logic across controllers.
+
+### Exact template match
+
+```php
+View::composer('partials/navigation', function (&$data) {
+    $data['menuItems'] = Navigation::getItems();
+});
+```
+
+Every time `partials/navigation` renders, `$this->menuItems` is available automatically.
+
+### Wildcard patterns
+
+```php
+View::composer('admin/*', function (&$data) {
+    $data['currentUser'] = Auth::user();
+    $data['notifications'] = Notification::unread();
+});
+```
+
+All templates under `admin/` will have `currentUser` and `notifications` injected.
+
+### Event-based composers
+
+You can also use the Event system directly:
+
+```php
+Event::on('core.view.compose:dashboard', function (&$data) {
+    $data['stats'] = Analytics::summary();
+});
+```
+
+---
+
+## Global Variables
+
+Variables available in every template:
+
+```php
+// Single global
+View::addGlobal('appName', 'My Application');
+
+// Multiple globals
+View::addGlobals([
+    'appName'  => 'My Application',
+    'appUrl'   => 'https://example.com',
+    'year'     => date('Y'),
+]);
+```
+
+In templates:
+
+```php
+<title><?= $this->raw('appName') ?></title>
+<footer>&copy; <?= $this->year ?></footer>
+```
+
+---
+
+## Template Caching
+
+Cache the rendered output of expensive templates using Core's built-in Cache component:
+
+```php
+// Cache for 1 hour
+echo View::from('reports/dashboard', $data)->cache(3600);
+
+// Cache for 24 hours
+echo View::from('pages/static-about')->cache(86400);
+```
+
+The cache key is automatically derived from the template name and a hash of the view data, so different data produces different cache entries.
+
+Requires the `Cache` component to be initialized:
+
+```php
+Cache::using(['files', 'memory']);
+```
+
+---
+
+## Template Fallbacks
+
+Pass an array of template paths to try in order. The first one that exists is used:
+
+```php
+// Try article-specific template, then category, then generic
+$view = View::from([
+    "articles/article-{$id}",
+    "articles/{$category}",
+    'articles/default',
+], $data);
+```
+
+If none exist, an `Exception` is thrown.
+
+---
+
+## Escape Strategies
+
+Four built-in strategies, extensible via the Filter system:
+
+| Strategy | Usage | Function |
+|----------|-------|----------|
+| `html` | Default `$this->key` | `htmlspecialchars()` |
+| `url` | Query parameters | `rawurlencode()` |
+| `js` | JavaScript strings | `json_encode()` with hex flags |
+| `css` | CSS values | Hex-escape non-alphanumerics |
+
+### Custom escape strategies
+
+Override or add strategies via the Filter system:
+
+```php
+// Override the 'html' strategy
+Filter::add('core.view.escape.html', function ($value) {
+    return htmlspecialchars($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+});
+
+// Add a custom strategy
+Filter::add('core.view.escape.markdown', function ($value) {
+    return Parsedown::instance()->text($value);
+});
+```
+
+Then use in templates:
+
+```php
+<?= $this->e($this->raw('content'), 'markdown') ?>
+```
+
+---
+
+## Adapter Interface
+
+The View engine is pluggable. Any class implementing `View\Adapter` can replace the built-in PHP engine:
+
+```php
+namespace View;
+
+interface Adapter {
+    public function __construct($path = null, $options = []);
+    public function render($template, $data = []);
+    public static function exists($path);
+    public static function addGlobal($key, $val);
+    public static function addGlobals(array $defs);
+    public static function addHelper($name, callable $fn);
+    public static function addHelpers(array $helpers);
+}
+```
+
+Example: swapping in a custom adapter:
+
+```php
+View::using(new MyTwigAdapter('/path/to/templates', ['cache' => '/tmp']));
+```
+
+---
+
+## Integration with Routes
+
+Views integrate directly with Core's Route system:
+
+```php
+// Return a View directly from a route
+Route::get('/about', function () {
+    return View::from('pages/about', ['title' => 'About']);
+});
+
+// Or pass a View as the callback
+Route::get('/home', View::from('pages/home'));
+```
+
+Views are also auto-rendered when added to a Response:
+
+```php
+Response::add(View::from('emails/welcome', $userData));
+```
+
+---
+
+## Full Example: Blog Application
+
+### Directory structure
+
+```
+templates/
+  layouts/
+    app.php
+  pages/
+    home.php
+    post.php
+  components/
+    post-card.php
+    pagination.php
+  partials/
+    sidebar.php
+```
+
+### `templates/layouts/app.php`
+
+```php
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><?= $this->yield('title', 'My Blog') ?></title>
+    <link rel="stylesheet" href="/css/app.css">
+    <?= $this->stack('styles') ?>
+</head>
+<body>
+    <nav>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <?php if (isset($this->currentUser)): ?>
+            <span>Welcome, <?= $this->currentUser ?></span>
+        <?php endif ?>
+    </nav>
+
+    <div class="container">
+        <?= $this->yield('content') ?>
+    </div>
+
+    <footer>&copy; <?= $this->year ?> My Blog</footer>
+
+    <script src="/js/app.js"></script>
+    <?= $this->stack('scripts') ?>
+</body>
+</html>
+```
+
+### `templates/pages/home.php`
+
+```php
+<?php $this->extend('layouts/app') ?>
+
+<?php $this->section('title') ?>Home - My Blog<?php $this->endSection() ?>
+
+<?php $this->section('content') ?>
+    <h1>Latest Posts</h1>
+
+    <?php foreach ($this->raw('posts') as $post): ?>
+        <?= $this->include('components/post-card', ['post' => $post]) ?>
+    <?php endforeach ?>
+
+    <?= $this->include('components/pagination', [
+        'currentPage' => $this->raw('page'),
+        'totalPages'  => $this->raw('totalPages'),
+    ]) ?>
+<?php $this->endSection() ?>
+```
+
+### `templates/components/post-card.php`
+
+```php
+<article class="post-card">
+    <h2><a href="/post/<?= $this->raw('post')['slug'] ?>">
+        <?= $this->raw('post')['title'] ?>
+    </a></h2>
+    <time><?= $this->formatDate($this->raw('post')['created_at'], 'M d, Y') ?></time>
+    <p><?= $this->truncate($this->raw('post')['excerpt'], 150) ?></p>
+</article>
+```
+
+### `templates/pages/post.php`
+
+```php
+<?php $this->extend('layouts/app') ?>
+
+<?php $this->section('title') ?><?= $this->title ?> - My Blog<?php $this->endSection() ?>
+
+<?php $this->push('styles') ?>
+    <link rel="stylesheet" href="/css/highlight.css">
+<?php $this->endPush() ?>
+
+<?php $this->push('scripts') ?>
+    <script src="/js/highlight.js"></script>
+<?php $this->endPush() ?>
+
+<?php $this->section('content') ?>
+    <article>
+        <h1><?= $this->title ?></h1>
+        <time><?= $this->formatDate($this->raw('date'), 'F j, Y') ?></time>
+        <div class="post-body">
+            <?= $this->raw('body') ?>
+        </div>
+    </article>
+
+    <?= $this->embed('partials/sidebar') ?>
+<?php $this->endSection() ?>
+```
+
+### Bootstrap code
+
+```php
+// Initialize
+View::using(new View\PHP(__DIR__ . '/templates'));
+
+// Register globals
+View::addGlobals([
+    'year' => date('Y'),
+]);
+
+// Register helpers
+View::helpers([
+    'formatDate' => function ($date, $fmt = 'Y-m-d') {
+        return date($fmt, strtotime($date));
+    },
+    'truncate' => function ($text, $len = 100) {
+        return mb_strlen($text) > $len ? mb_substr($text, 0, $len) . '...' : $text;
+    },
+]);
+
+// Auto-inject currentUser into all templates
+View::composer('*', function (&$data) {
+    $data['currentUser'] = Session::get('user_name');
+});
+
+// Auto-inject sidebar data
+View::composer('partials/sidebar', function (&$data) {
+    $data['recentPosts'] = Post::recent(5);
+    $data['categories']  = Category::all();
+});
+
+// Routes
+Route::get('/', function () {
+    $page  = (int) Request::get('page', 1);
+    $posts = Post::paginate($page, 10);
+
+    return View::from('pages/home', [
+        'posts'      => $posts->items,
+        'page'       => $page,
+        'totalPages' => $posts->lastPage,
+    ]);
+});
+
+Route::get('/post/:slug', function ($slug) {
+    $post = Post::findBySlug($slug);
+
+    return View::from([
+        "pages/post-{$slug}",  // Try slug-specific template first
+        'pages/post',          // Fall back to generic
+    ], [
+        'title' => $post->title,
+        'date'  => $post->created_at,
+        'body'  => $post->rendered_body,
+    ])->cache(600);  // Cache for 10 minutes
+});
+```
+
+---
+
+## API Reference
+
+### View (Facade)
+
+| Method | Description |
+|--------|-------------|
+| `View::using(Adapter $handler)` | Set the template engine adapter |
+| `View::from($template, $data = null)` | Create a view instance |
+| `View::exists($path)` | Check if a template exists |
+| `View::helper($name, $fn)` | Register a template helper |
+| `View::helpers(array $helpers)` | Register multiple helpers |
+| `View::composer($pattern, $fn)` | Register a view composer |
+| `View::addGlobal($key, $val)` | Add a global variable |
+| `View::addGlobals(array $defs)` | Add multiple globals |
+| `$view->with($data)` | Assign data to the view |
+| `$view->cache($ttl)` | Cache the rendered output |
+
+### View\Scope (Template Context)
+
+Available as `$this` inside templates:
+
+| Method | Description |
+|--------|-------------|
+| `$this->key` | Access variable (auto-escaped) |
+| `$this->raw('key')` | Access variable (unescaped) |
+| `$this->e($value, $strategy)` | Manual escape (html/url/js/css) |
+| `$this->extend($layout)` | Declare parent layout |
+| `$this->section($name)` | Begin section capture |
+| `$this->endSection()` | End section capture |
+| `$this->yield($name, $default)` | Output a section |
+| `$this->push($name)` | Begin stack push |
+| `$this->endPush()` | End stack push |
+| `$this->prepend($name)` | Begin stack prepend |
+| `$this->endPrepend()` | End stack prepend |
+| `$this->stack($name)` | Output a stack |
+| `$this->include($tpl, $data)` | Include template (isolated data) |
+| `$this->embed($tpl, $data)` | Embed template (inherited data) |

--- a/examples/views/demo.php
+++ b/examples/views/demo.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Core View Demo
+ *
+ * This script demonstrates all major features of the enhanced View engine.
+ * Run it with: php examples/views/demo.php
+ *
+ * Features demonstrated:
+ *   1. Template inheritance (extend/section/yield)
+ *   2. Auto-escaping & raw output
+ *   3. Stacks (CSS/JS injection)
+ *   4. Include (isolated) vs Embed (inheriting)
+ *   5. Custom helpers
+ *   6. View composers
+ *   7. Global variables
+ *   8. Template fallbacks
+ *   9. Render caching
+ */
+
+require_once __DIR__ . '/../../classes/Loader.php';
+
+// ─── Setup ───────────────────────────────────────────────────────
+View::using(new View\PHP(__DIR__ . '/templates'));
+
+// ─── Global variables ────────────────────────────────────────────
+View::addGlobals([
+    'appName' => 'Core Blog',
+    'year'    => date('Y'),
+]);
+
+// ─── Custom helpers ──────────────────────────────────────────────
+View::helpers([
+    'formatDate' => function ($date, $fmt = 'Y-m-d') {
+        return date($fmt, strtotime($date));
+    },
+    'truncate' => function ($text, $len = 100) {
+        return mb_strlen($text) > $len ? mb_substr($text, 0, $len) . '...' : $text;
+    },
+]);
+
+// ─── View composers ─────────────────────────────────────────────
+// This composer fires for every template matching "pages/*"
+View::composer('pages/*', function (&$data) {
+    $data['composerNote'] = 'Data injected by wildcard composer';
+});
+
+// ─── Sample data ─────────────────────────────────────────────────
+$articles = [
+    [
+        'id'      => 1,
+        'title'   => 'Getting Started with Core',
+        'excerpt' => 'Learn how to build applications rapidly with the Core framework. This guide covers installation, routing, and your first view template.',
+        'date'    => '2024-12-01',
+    ],
+    [
+        'id'      => 2,
+        'title'   => 'Template Inheritance Explained',
+        'excerpt' => 'Master the extend/section/yield pattern to build DRY layouts. No more copy-pasting headers and footers across pages.',
+        'date'    => '2024-12-15',
+    ],
+    [
+        'id'      => 3,
+        'title'   => 'XSS Prevention & Auto-Escaping',
+        'excerpt' => 'How Core View\'s auto-escaping keeps your app safe by default, and when to use raw() for trusted content.',
+        'date'    => '2025-01-05',
+    ],
+];
+
+
+echo "=== DEMO 1: Home page with template inheritance ===\n\n";
+
+$html = (string) View::from('pages/home', ['articles' => $articles]);
+echo $html;
+echo "\n\n";
+
+
+echo "=== DEMO 2: Article page with stacks and embeds ===\n\n";
+
+$html = (string) View::from('pages/article', [
+    'title'  => 'Getting Started with Core',
+    'author' => 'Stefano Azzolini',
+    'date'   => '2024-12-01',
+    'body'   => '<p>This is the <strong>article body</strong> with HTML content.</p>',
+]);
+echo $html;
+echo "\n\n";
+
+
+echo "=== DEMO 3: Auto-escaping prevents XSS ===\n\n";
+
+// This simulates user-controlled input with a malicious script tag
+$malicious = '<script>alert("xss")</script>';
+View::using(new View\PHP(__DIR__ . '/templates'));
+
+// Create a simple inline template for this demo
+$tmpDir = sys_get_temp_dir() . '/core_view_demo';
+@mkdir($tmpDir);
+file_put_contents($tmpDir . '/xss_test.php', '<p>User says: <?= $this->message ?></p>');
+View::using(new View\PHP($tmpDir));
+
+$safe = (string) View::from('xss_test', ['message' => $malicious]);
+echo "Input:  $malicious\n";
+echo "Output: $safe\n";
+echo "The <script> tag is safely escaped!\n\n";
+
+// Restore original template path
+View::using(new View\PHP(__DIR__ . '/templates'));
+
+
+echo "=== DEMO 4: Template fallbacks ===\n\n";
+
+// Create temp templates for fallback demo
+$tmpDir2 = sys_get_temp_dir() . '/core_view_fallback';
+@mkdir($tmpDir2);
+file_put_contents($tmpDir2 . '/article-specific.php', 'Specific article template');
+file_put_contents($tmpDir2 . '/article-generic.php', 'Generic article template');
+
+View::using(new View\PHP($tmpDir2));
+
+// First existing template wins
+$view = View::from(['article-missing', 'article-specific', 'article-generic']);
+echo "Fallback result: " . $view . "\n\n";
+
+// Clean up
+unlink($tmpDir2 . '/article-specific.php');
+unlink($tmpDir2 . '/article-generic.php');
+rmdir($tmpDir2);
+@unlink($tmpDir . '/xss_test.php');
+@rmdir($tmpDir);
+
+echo "=== All demos complete ===\n";

--- a/examples/views/templates/components/article-card.php
+++ b/examples/views/templates/components/article-card.php
@@ -1,0 +1,9 @@
+<div style="border: 1px solid #dfe6e9; border-radius: 8px; padding: 1.5rem; margin-bottom: 1rem;">
+    <h3 style="margin-top: 0;">
+        <a href="/article/<?= $this->raw('article')['id'] ?>"><?= $this->raw('article')['title'] ?></a>
+    </h3>
+    <p style="color: #636e72;"><?= $this->truncate($this->raw('article')['excerpt'], 120) ?></p>
+    <small>
+        <?= $this->formatDate($this->raw('article')['date'], 'M d, Y') ?>
+    </small>
+</div>

--- a/examples/views/templates/layouts/main.php
+++ b/examples/views/templates/layouts/main.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?= $this->yield('title', 'Core View Demo') ?></title>
+    <title><?= yields('title', 'Core View Demo') ?></title>
     <style>
         body { font-family: system-ui, sans-serif; margin: 0; color: #333; }
         header { background: #2d3436; color: white; padding: 1rem 2rem; }
@@ -11,12 +11,12 @@
         main { max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
         footer { text-align: center; padding: 2rem; color: #636e72; border-top: 1px solid #dfe6e9; margin-top: 3rem; }
     </style>
-    <?= $this->stack('styles') ?>
+    <?= stack('styles') ?>
 </head>
 <body>
     <header>
         <nav>
-            <strong><?= $this->raw('appName') ?></strong>
+            <strong><?= raw('appName') ?></strong>
             &nbsp;&nbsp;
             <a href="/">Home</a>
             <a href="/about">About</a>
@@ -25,13 +25,13 @@
     </header>
 
     <main>
-        <?= $this->yield('content') ?>
+        <?= yields('content') ?>
     </main>
 
     <footer>
-        <?= $this->yield('footer', '&copy; ' . $this->raw('year') . ' ' . $this->raw('appName')) ?>
+        <?= yields('footer', '&copy; ' . raw('year') . ' ' . raw('appName')) ?>
     </footer>
 
-    <?= $this->stack('scripts') ?>
+    <?= stack('scripts') ?>
 </body>
 </html>

--- a/examples/views/templates/layouts/main.php
+++ b/examples/views/templates/layouts/main.php
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $this->yield('title', 'Core View Demo') ?></title>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 0; color: #333; }
+        header { background: #2d3436; color: white; padding: 1rem 2rem; }
+        header nav a { color: #dfe6e9; text-decoration: none; margin-right: 1rem; }
+        main { max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
+        footer { text-align: center; padding: 2rem; color: #636e72; border-top: 1px solid #dfe6e9; margin-top: 3rem; }
+    </style>
+    <?= $this->stack('styles') ?>
+</head>
+<body>
+    <header>
+        <nav>
+            <strong><?= $this->raw('appName') ?></strong>
+            &nbsp;&nbsp;
+            <a href="/">Home</a>
+            <a href="/about">About</a>
+            <a href="/contact">Contact</a>
+        </nav>
+    </header>
+
+    <main>
+        <?= $this->yield('content') ?>
+    </main>
+
+    <footer>
+        <?= $this->yield('footer', '&copy; ' . $this->raw('year') . ' ' . $this->raw('appName')) ?>
+    </footer>
+
+    <?= $this->stack('scripts') ?>
+</body>
+</html>

--- a/examples/views/templates/pages/article.php
+++ b/examples/views/templates/pages/article.php
@@ -1,0 +1,37 @@
+<?php $this->extend('layouts/main') ?>
+
+<?php $this->section('title') ?><?= $this->title ?> - <?= $this->raw('appName') ?><?php $this->endSection() ?>
+
+<?php $this->push('styles') ?>
+    <style>
+        .article-body { line-height: 1.8; }
+        .article-meta { color: #636e72; font-size: 0.9rem; margin-bottom: 2rem; }
+    </style>
+<?php $this->endPush() ?>
+
+<?php $this->push('scripts') ?>
+    <script>
+        // Highlight code blocks, reading time, etc.
+        console.log('Article page loaded');
+    </script>
+<?php $this->endPush() ?>
+
+<?php $this->section('content') ?>
+    <article>
+        <h1><?= $this->title ?></h1>
+
+        <div class="article-meta">
+            By <?= $this->author ?> &middot;
+            <?= $this->formatDate($this->raw('date'), 'F j, Y') ?>
+        </div>
+
+        <div class="article-body">
+            <?= $this->raw('body') ?>
+        </div>
+    </article>
+
+    <hr>
+
+    <h3>Related Articles</h3>
+    <?= $this->embed('partials/related') ?>
+<?php $this->endSection() ?>

--- a/examples/views/templates/pages/article.php
+++ b/examples/views/templates/pages/article.php
@@ -1,37 +1,37 @@
-<?php $this->extend('layouts/main') ?>
+<?php extend('layouts/main') ?>
 
-<?php $this->section('title') ?><?= $this->title ?> - <?= $this->raw('appName') ?><?php $this->endSection() ?>
+<?php section('title') ?><?= $this->title ?> - <?= raw('appName') ?><?php endSection() ?>
 
-<?php $this->push('styles') ?>
+<?php push('styles') ?>
     <style>
         .article-body { line-height: 1.8; }
         .article-meta { color: #636e72; font-size: 0.9rem; margin-bottom: 2rem; }
     </style>
-<?php $this->endPush() ?>
+<?php endPush() ?>
 
-<?php $this->push('scripts') ?>
+<?php push('scripts') ?>
     <script>
         // Highlight code blocks, reading time, etc.
         console.log('Article page loaded');
     </script>
-<?php $this->endPush() ?>
+<?php endPush() ?>
 
-<?php $this->section('content') ?>
+<?php section('content') ?>
     <article>
         <h1><?= $this->title ?></h1>
 
         <div class="article-meta">
             By <?= $this->author ?> &middot;
-            <?= $this->formatDate($this->raw('date'), 'F j, Y') ?>
+            <?= $this->formatDate(raw('date'), 'F j, Y') ?>
         </div>
 
         <div class="article-body">
-            <?= $this->raw('body') ?>
+            <?= raw('body') ?>
         </div>
     </article>
 
     <hr>
 
     <h3>Related Articles</h3>
-    <?= $this->embed('partials/related') ?>
-<?php $this->endSection() ?>
+    <?= embed('partials/related') ?>
+<?php endSection() ?>

--- a/examples/views/templates/pages/home.php
+++ b/examples/views/templates/pages/home.php
@@ -1,0 +1,13 @@
+<?php $this->extend('layouts/main') ?>
+
+<?php $this->section('title') ?>Home - <?= $this->raw('appName') ?><?php $this->endSection() ?>
+
+<?php $this->section('content') ?>
+    <h1>Welcome to Core View</h1>
+    <p>This is the home page rendered with template inheritance.</p>
+
+    <h2>Featured Articles</h2>
+    <?php foreach ($this->raw('articles') as $article): ?>
+        <?= $this->include('components/article-card', ['article' => $article]) ?>
+    <?php endforeach ?>
+<?php $this->endSection() ?>

--- a/examples/views/templates/pages/home.php
+++ b/examples/views/templates/pages/home.php
@@ -1,13 +1,13 @@
-<?php $this->extend('layouts/main') ?>
+<?php extend('layouts/main') ?>
 
-<?php $this->section('title') ?>Home - <?= $this->raw('appName') ?><?php $this->endSection() ?>
+<?php section('title') ?>Home - <?= raw('appName') ?><?php endSection() ?>
 
-<?php $this->section('content') ?>
+<?php section('content') ?>
     <h1>Welcome to Core View</h1>
     <p>This is the home page rendered with template inheritance.</p>
 
     <h2>Featured Articles</h2>
-    <?php foreach ($this->raw('articles') as $article): ?>
-        <?= $this->include('components/article-card', ['article' => $article]) ?>
+    <?php foreach (raw('articles') as $article): ?>
+        <?= partial('components/article-card', ['article' => $article]) ?>
     <?php endforeach ?>
-<?php $this->endSection() ?>
+<?php endSection() ?>

--- a/examples/views/templates/partials/related.php
+++ b/examples/views/templates/partials/related.php
@@ -1,0 +1,8 @@
+<?php
+// This partial uses embed(), so it inherits the parent template's data.
+// It can access $this->title, $this->author, etc. from the article page.
+?>
+<ul>
+    <li><a href="#">More by <?= $this->author ?></a></li>
+    <li><a href="/">Back to all articles</a></li>
+</ul>

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -1,90 +1,175 @@
 <?php
 
-class ViewTest extends PHPUnit_Framework_TestCase {
+class ViewTest extends \PHPUnit\Framework\TestCase {
 
-	public function __construct() {
-		// Build some templates
-		$TEMPLATE_DIR = sys_get_temp_dir();
-		@mkdir("$TEMPLATE_DIR/special");
+	protected static $TEMPLATE_DIR;
 
-		file_put_contents("$TEMPLATE_DIR/special/hello.php", <<<'EOT'
-Hello, <?= $this->name ?>!
-EOT
+	public static function setUpBeforeClass(): void {
+		self::$TEMPLATE_DIR = sys_get_temp_dir() . '/core_view_test_' . getmypid();
+		@mkdir(self::$TEMPLATE_DIR);
+		@mkdir(self::$TEMPLATE_DIR . '/layouts');
+		@mkdir(self::$TEMPLATE_DIR . '/pages');
+		@mkdir(self::$TEMPLATE_DIR . '/components');
+		@mkdir(self::$TEMPLATE_DIR . '/special');
+		@mkdir(self::$TEMPLATE_DIR . '/admin');
+
+		// ── Basic templates ──────────────────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/test.php', 'TESTIFICATE');
+
+		file_put_contents(self::$TEMPLATE_DIR . '/test_var.php', '<?=$this->var?>');
+
+		file_put_contents(self::$TEMPLATE_DIR . '/global.php', '<?=$this->raw("THE_DARKNESS")?>');
+
+		file_put_contents(self::$TEMPLATE_DIR . '/special/hello.php',
+			'Hello, <?= $this->name ?>!'
 		);
 
-		file_put_contents("$TEMPLATE_DIR/test.php", <<<'EOT'
-TESTIFICATE
-EOT
+		// ── Fallback templates ───────────────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/article-123.php',
+			'ARTICLE-123:<?=$this->var?>'
+		);
+		file_put_contents(self::$TEMPLATE_DIR . '/article.php',
+			'ARTICLE:<?=$this->var?>'
 		);
 
-		file_put_contents("$TEMPLATE_DIR/global.php", <<<'EOT'
-<?=$this->THE_DARKNESS?>
-EOT
+		// ── Include / Embed templates ────────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/components/card.php',
+			'<div class="card"><?=$this->title?></div>'
 		);
 
-		file_put_contents("$TEMPLATE_DIR/test_var.php", <<<'EOT'
-<?=$this->var?>
-EOT
+		file_put_contents(self::$TEMPLATE_DIR . '/index_include.php',
+			'[<?= $this->include("components/card", ["title" => "Isolated"]) ?>]'
 		);
 
-    file_put_contents("$TEMPLATE_DIR/article-123.php", <<<'EOT'
-ARTICLE-123:<?=$this->var?>
-EOT
-    );
-
-    file_put_contents("$TEMPLATE_DIR/article.php", <<<'EOT'
-ARTICLE:<?=$this->var?>
-EOT
-    );
-
-		file_put_contents("$TEMPLATE_DIR/index_pass.php", <<<'EOT'
-[<?= $this->partial('special/hello') ?>]
-EOT
+		file_put_contents(self::$TEMPLATE_DIR . '/index_embed.php',
+			'[<?= $this->embed("special/hello") ?>]'
 		);
 
-		file_put_contents("$TEMPLATE_DIR/index_override.php", <<<'EOT'
-[<?= $this->partial('special/hello',['name'=>'Daryl']) ?>]
-EOT
+		file_put_contents(self::$TEMPLATE_DIR . '/index_embed_override.php',
+			'[<?= $this->embed("special/hello", ["name" => "Daryl"]) ?>]'
+		);
+
+		// ── Escaping templates ───────────────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/escape_auto.php',
+			'<?=$this->content?>'
+		);
+
+		file_put_contents(self::$TEMPLATE_DIR . '/escape_raw.php',
+			'<?=$this->raw("content")?>'
+		);
+
+		file_put_contents(self::$TEMPLATE_DIR . '/escape_manual.php',
+			'<?=$this->e($this->raw("url"), "url")?>'
+		);
+
+		// ── Layout / Inheritance templates ───────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/layouts/main.php', implode('', [
+			'<html>',
+			'<head><?=$this->stack("styles")?></head>',
+			'<body>',
+			'<header><?=$this->yield("header", "Default Header")?></header>',
+			'<main><?=$this->yield("content")?></main>',
+			'<footer><?=$this->yield("footer", "Default Footer")?></footer>',
+			'<?=$this->stack("scripts")?>',
+			'</body>',
+			'</html>',
+		]));
+
+		file_put_contents(self::$TEMPLATE_DIR . '/pages/home.php', implode("\n", [
+			'<?php $this->extend("layouts/main") ?>',
+			'<?php $this->section("header") ?>Welcome<?php $this->endSection() ?>',
+			'<?php $this->section("content") ?>Home Body<?php $this->endSection() ?>',
+		]));
+
+		file_put_contents(self::$TEMPLATE_DIR . '/pages/minimal.php', implode("\n", [
+			'<?php $this->extend("layouts/main") ?>',
+			'<?php $this->section("content") ?>Minimal<?php $this->endSection() ?>',
+		]));
+
+		// ── Stack templates ──────────────────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/pages/with_stacks.php', implode("\n", [
+			'<?php $this->extend("layouts/main") ?>',
+			'<?php $this->push("styles") ?><link rel="stylesheet" href="app.css"><?php $this->endPush() ?>',
+			'<?php $this->push("scripts") ?><script src="app.js"></script><?php $this->endPush() ?>',
+			'<?php $this->section("content") ?>Stacked<?php $this->endSection() ?>',
+		]));
+
+		// ── Nested layout (grandchild) ───────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/layouts/admin.php', implode("\n", [
+			'<?php $this->extend("layouts/main") ?>',
+			'<?php $this->section("header") ?>Admin Panel<?php $this->endSection() ?>',
+			'<?php $this->section("content") ?><nav>Sidebar</nav><div><?=$this->yield("admin_content")?></div><?php $this->endSection() ?>',
+		]));
+
+		file_put_contents(self::$TEMPLATE_DIR . '/admin/dashboard.php', implode("\n", [
+			'<?php $this->extend("layouts/admin") ?>',
+			'<?php $this->section("admin_content") ?>Dashboard<?php $this->endSection() ?>',
+		]));
+
+		// ── Helper template ──────────────────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/helper_test.php',
+			'<?=$this->formatDate("2024-01-15", "d/m/Y")?>'
+		);
+
+		// ── isset check template ─────────────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/isset_test.php',
+			'<?=isset($this->defined) ? "yes" : "no"?>:<?=isset($this->undefined) ? "yes" : "no"?>'
+		);
+
+		// ── Composer test template ───────────────────────────────
+
+		file_put_contents(self::$TEMPLATE_DIR . '/admin/users.php',
+			'<?=$this->raw("injected")?>'
 		);
 
 		// Init View handler
-		View::using(new View\PHP($TEMPLATE_DIR));
+		View::using(new View\PHP(self::$TEMPLATE_DIR));
 	}
 
+	public static function tearDownAfterClass(): void {
+		// Clean up temp files
+		$it = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator(self::$TEMPLATE_DIR, RecursiveDirectoryIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($it as $file) {
+			$file->isDir() ? rmdir($file->getRealPath()) : unlink($file->getRealPath());
+		}
+		rmdir(self::$TEMPLATE_DIR);
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// Basic Rendering
+	// ═══════════════════════════════════════════════════════════════
+
 	public function testRender() {
-		$results = (string) View::from('test');
-		$this->assertEquals('TESTIFICATE', $results);
+		$this->assertEquals('TESTIFICATE', (string) View::from('test'));
 	}
 
 	public function testRenderWithParameters() {
-		$results = (string) View::from('test_var')->with(['var' => 1]);
-		$this->assertEquals('1', $results);
+		$this->assertEquals('1', (string) View::from('test_var', ['var' => 1]));
 	}
 
-	public function testRenderWithParametersShorthand() {
-		$results = (string) View::from('test_var')->with(['var' => 1]);
-		$this->assertEquals('1', $results);
+	public function testWithMergeOrder() {
+		// Last with() call should win
+		$view = View::from('test_var', ['var' => 'first']);
+		$view->with(['var' => 'second']);
+		$this->assertEquals('second', (string) $view);
 	}
 
 	public function testGlobalParameters() {
 		View::addGlobal('THE_DARKNESS', 'Jakie');
-		$results = (string) View::from('global');
-		$this->assertEquals('Jakie', $results);
-	}
-
-	public function testPHPViewSimpleRenderWithVariables() {
-		$results = (string) View::from('special/hello', ['name' => 'Rick']);
-		$this->assertEquals('Hello, Rick!', $results);
-	}
-
-	public function testPHPViewPartialsRenderWithVariables() {
-		$results = (string) View::from('index_pass', ['name' => 'Rick']);
-		$this->assertEquals('[Hello, Rick!]', $results);
-	}
-
-	public function testPHPViewPartialsOverridingVariables() {
-		$results = (string) View::from('index_override', ['name' => 'Rick']);
-		$this->assertEquals('[Hello, Daryl!]', $results);
+		$this->assertEquals('Jakie', (string) View::from('global'));
 	}
 
 	public function testTemplateExists() {
@@ -92,39 +177,193 @@ EOT
 		$this->assertFalse(View::exists('im/fake/template'));
 	}
 
-  public function testFallbackException() {
-    // Test exception on fail
-    try {
-      $view = View::from([
-        'foo',
-        'bar',
-        'baz',
-      ]);
-    } catch(Exception $e){
-      // Ok, exception catched
-      return $this->assertTrue(true,'Exception on view fallback error');
-    }
-    // Error, an exception must be throwed
-    return $this->assertTrue(false,'Exception on view fallback error');
-  }
 
-  public function testFallback() {
-    $this->assertEquals('ARTICLE-123:626', View::from([
-      'undefined',
-      'article-123',
-      'article',
-    ],[
-      'var' => 626
-    ]));
+	// ═══════════════════════════════════════════════════════════════
+	// Fallback Templates
+	// ═══════════════════════════════════════════════════════════════
 
-    $this->assertEquals('ARTICLE:626', View::from([
-      'undefined',
-      'article-9999',
-      'article',
-    ],[
-      'var' => 626
-    ]));
+	public function testFallbackException() {
+		try {
+			View::from(['foo', 'bar', 'baz']);
+		} catch (Exception $e) {
+			return $this->assertTrue(true);
+		}
+		$this->assertTrue(false, 'Exception should have been thrown');
+	}
 
-  }
+	public function testFallback() {
+		$this->assertEquals('ARTICLE-123:626', (string) View::from([
+			'undefined', 'article-123', 'article',
+		], ['var' => 626]));
+
+		$this->assertEquals('ARTICLE:626', (string) View::from([
+			'undefined', 'article-9999', 'article',
+		], ['var' => 626]));
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// Auto-Escaping
+	// ═══════════════════════════════════════════════════════════════
+
+	public function testAutoEscapeHtml() {
+		$html = '<script>alert("xss")</script>';
+		$result = (string) View::from('escape_auto', ['content' => $html]);
+		$this->assertEquals(htmlspecialchars($html, ENT_QUOTES, 'UTF-8'), $result);
+		$this->assertStringNotContainsString('<script>', $result);
+	}
+
+	public function testRawAccess() {
+		$html = '<b>bold</b>';
+		$result = (string) View::from('escape_raw', ['content' => $html]);
+		$this->assertEquals($html, $result);
+	}
+
+	public function testManualEscapeUrl() {
+		$url = 'hello world&foo=bar';
+		$result = (string) View::from('escape_manual', ['url' => $url]);
+		$this->assertEquals(rawurlencode($url), $result);
+	}
+
+	public function testNonStringNotEscaped() {
+		// Integers and other non-strings should pass through without escaping
+		$result = (string) View::from('test_var', ['var' => 42]);
+		$this->assertEquals('42', $result);
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// __isset behavior
+	// ═══════════════════════════════════════════════════════════════
+
+	public function testIssetBehavior() {
+		$result = (string) View::from('isset_test', ['defined' => 'value']);
+		$this->assertEquals('yes:no', $result);
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// Include (isolated) and Embed (inheriting)
+	// ═══════════════════════════════════════════════════════════════
+
+	public function testIncludeIsolated() {
+		$result = (string) View::from('index_include', ['name' => 'Rick']);
+		// The included component should only see 'title', not 'name'
+		$this->assertEquals('[<div class="card">Isolated</div>]', $result);
+	}
+
+	public function testEmbedInheritsData() {
+		$result = (string) View::from('index_embed', ['name' => 'Rick']);
+		// embed() inherits parent data, so 'name' should be available
+		$this->assertEquals('[Hello, Rick!]', $result);
+	}
+
+	public function testEmbedOverridesData() {
+		$result = (string) View::from('index_embed_override', ['name' => 'Rick']);
+		// embed() with override: 'Daryl' should win over 'Rick'
+		$this->assertEquals('[Hello, Daryl!]', $result);
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// Template Inheritance (extend / section / yield)
+	// ═══════════════════════════════════════════════════════════════
+
+	public function testBasicInheritance() {
+		$result = (string) View::from('pages/home');
+		$this->assertStringContainsString('<header>Welcome</header>', $result);
+		$this->assertStringContainsString('<main>Home Body</main>', $result);
+		$this->assertStringContainsString('<html>', $result);
+		$this->assertStringContainsString('</html>', $result);
+	}
+
+	public function testYieldDefaults() {
+		// pages/minimal only defines 'content', so 'header' and 'footer' should use defaults
+		$result = (string) View::from('pages/minimal');
+		$this->assertStringContainsString('<header>Default Header</header>', $result);
+		$this->assertStringContainsString('<main>Minimal</main>', $result);
+		$this->assertStringContainsString('<footer>Default Footer</footer>', $result);
+	}
+
+	public function testMultiLevelInheritance() {
+		// admin/dashboard extends layouts/admin which extends layouts/main
+		$result = (string) View::from('admin/dashboard');
+		$this->assertStringContainsString('<header>Admin Panel</header>', $result);
+		$this->assertStringContainsString('Dashboard', $result);
+		$this->assertStringContainsString('<nav>Sidebar</nav>', $result);
+		$this->assertStringContainsString('<html>', $result);
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// Stacks (push / stack)
+	// ═══════════════════════════════════════════════════════════════
+
+	public function testStacks() {
+		$result = (string) View::from('pages/with_stacks');
+		$this->assertStringContainsString('<link rel="stylesheet" href="app.css">', $result);
+		$this->assertStringContainsString('<script src="app.js"></script>', $result);
+		$this->assertStringContainsString('<main>Stacked</main>', $result);
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// Custom Helpers
+	// ═══════════════════════════════════════════════════════════════
+
+	public function testCustomHelper() {
+		View::helper('formatDate', function ($date, $fmt = 'Y-m-d') {
+			return date($fmt, strtotime($date));
+		});
+
+		$result = (string) View::from('helper_test');
+		$this->assertEquals('15/01/2024', $result);
+	}
+
+	public function testUnknownHelperThrows() {
+		file_put_contents(self::$TEMPLATE_DIR . '/bad_helper.php', '<?=$this->nonExistent()?>');
+		$thrown = false;
+		try {
+			(string) View::from('bad_helper');
+		} catch (\BadMethodCallException $e) {
+			$thrown = true;
+			// Clean any leftover output buffers from the sandboxed include
+			while (ob_get_level() > 1) ob_end_clean();
+		}
+		$this->assertTrue($thrown, 'BadMethodCallException should have been thrown');
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// View Composers
+	// ═══════════════════════════════════════════════════════════════
+
+	public function testComposerExactMatch() {
+		View::composer('admin/users', function (&$data) {
+			$data['injected'] = 'composer_value';
+		});
+
+		$result = (string) View::from('admin/users');
+		$this->assertEquals('composer_value', $result);
+	}
+
+	public function testComposerWildcard() {
+		View::composer('admin/*', function (&$data) {
+			$data['injected'] = 'wildcard_value';
+		});
+
+		$result = (string) View::from('admin/users');
+		$this->assertStringContainsString('wildcard_value', $result);
+	}
+
+
+	// ═══════════════════════════════════════════════════════════════
+	// Caching
+	// ═══════════════════════════════════════════════════════════════
+
+	public function testCacheChainable() {
+		$view = View::from('test')->cache(3600);
+		$this->assertEquals('TESTIFICATE', (string) $view);
+	}
 
 }


### PR DESCRIPTION
Redesign the View\PHP template engine with a new View\Scope execution
context that replaces the old PHPContext. This brings the built-in renderer
to feature parity with mature engines like Blade and Twig while keeping
the zero-dependency, pure-PHP-template philosophy.

New features:
- Template inheritance: extend(), section()/endSection(), yield()
- Safe-by-default auto-escaping via __get with raw() opt-out
- Manual escape strategies: e($val, 'html|url|js|css') extensible via Filter
- Asset stacks: push()/endPush(), prepend()/endPrepend(), stack()
- Isolated includes vs data-inheriting embeds (replaces partial())
- View composers with wildcard pattern matching
- Custom template helpers registered via View::helper()
- Render caching via View::from(...)->cache($ttl) using Cache component
- Fixed with() merge order (last call wins)
- Truthful __isset() behavior

Includes comprehensive test suite (24 tests, 37 assertions), full
documentation (docs/View.md), and working example templates with demo script.

https://claude.ai/code/session_01KbJBfLAUVAeasMZQHsqwBQ